### PR TITLE
Handle missing beanDescription in flex list

### DIFF
--- a/AbstractBusinessService.java
+++ b/AbstractBusinessService.java
@@ -230,7 +230,7 @@ public abstract class AbstractBusinessService {
                 }
                 catch (Exception e) {
                     // cannot access the property
-                    continue;
+                    // ignore bean description and keep collected values
                 }
 
                 ret.add(newMap);


### PR DESCRIPTION
## Summary
- prevent buildFlexList from discarding beans when `beanDescription` property is absent

## Testing
- `javac AbstractBusinessService.java` *(fails: package ... does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_6892f64f384483278106d186f108f2be